### PR TITLE
Fix query_key in eager loading has_many relationships

### DIFF
--- a/lib/Relationship.php
+++ b/lib/Relationship.php
@@ -168,7 +168,8 @@ abstract class AbstractRelationship implements InterfaceRelationship
 			}
 			$options['joins'] = $this->construct_inner_join_sql($through_table, true);
 
-                        $query_key = $this->primary_key[0];
+                        // XXX this seems to be the wrong key in many_through relation ships?
+                        // $query_key = $this->primary_key[0];
 
 			// reset keys
 			$this->primary_key = $pk;

--- a/lib/Relationship.php
+++ b/lib/Relationship.php
@@ -168,16 +168,23 @@ abstract class AbstractRelationship implements InterfaceRelationship
 			}
 			$options['joins'] = $this->construct_inner_join_sql($through_table, true);
 
-			$query_key = $this->primary_key[0];
+                        $query_key = $this->primary_key[0];
 
 			// reset keys
 			$this->primary_key = $pk;
 			$this->foreign_key = $fk;
+
+                        $query_key = $this->foreign_key[0];
 		}
 
 		$options = $this->unset_non_finder_options($options);
 
 		$class = $this->class_name;
+
+                if (!array_key_exists('select', $options)) {
+                  $options['select'] = $class::table()->get_fully_qualified_table_name() . '.*';
+                }
+                $options['select'] .= ",$query_key";
 
 		$related_models = $class::find('all', $options);
 		$used_models = array();


### PR DESCRIPTION
I had problems with a has_many through relationship and eager loading, the tables are (excerpts)

CREATE TABLE categories
(
   id INT NOT NULL PRIMARY KEY AUTO_INCREMENT,
   name VARCHAR(100) NOT NULL,
);

CREATE TABLE products
(
  id INT NOT NULL PRIMARY KEY AUTO_INCREMENT,
  name VARCHAR(100) NOT NULL
);

CREATE TABLE product_to_categories
(
   product_id INT NOT NULL,
   category_id INT NOT NULL,

   -- constraints
   UNIQUE(product_id, category_id),
   FOREIGN KEY (product_id) REFERENCES products(id) ON DELETE CASCADE,
   FOREIGN KEY (category_id) REFERENCES categories(id) ON DELETE CASCADE
) ENGINE=InnoDB;

The relationships are:

class Category extends MyModel {
  static $has_many =
    array(          array('products',
                'through' => 'product_to_categories'),
          array('product_to_categories'));
};

class Product extends MyModel {
  static $has_many =
          array('categories',
                'through' => 'product_to_categories'),
          array('product_to_categories'));
};

Dispatching the returned models to the right relationships was broken because

a) the query key was wrong
b) the correct foreign key to be used as the dispatching key was not included in the result

I hope I didn't misunderstand something!?

Regards, manuel
